### PR TITLE
chore: rename project to `neuron`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 ## Summary
 
-> Please summarize your changes, describing *what* they are and *why* they were made.
-
 ...
 
 ## Changelog
@@ -14,35 +12,15 @@
 
 ### Instructions
 
-> Please describe relevant instructions, configurations, etc. for testing your changes.
-
 ...
 
 ### Platforms
-
-> Please select any platforms where your changes have been tested.
 
 - **Desktop**
   - [ ] MacOS
   - [ ] Linux
   - [ ] Windows
-- **Mobile**
-  - [ ] iOS
-  - [ ] Android
-- **Web**
-  - [ ] Chrome
-  - [ ] Firefox
-  - [ ] Brave
-  - [ ] Safari
-
-## Checklist
-
-> Please tick the following boxes that are relevant to your changes.
-
-- [ ] I have followed the contribution guidelines for this project
-- [ ] I have performed a self-review of my changes
-- [ ] I have added or modified tests, proving my changes work as intended
-- [ ] I have added comments to my code for hard-to-understand areas
-- [ ] I have verified that new and existing unit tests pass locally with my changes
-- [ ] I have verified that my latest changes pass CI workflows for testing and linting
-- [ ] I have made corresponding changes to the documentation
+- **Environments**
+  - [ ] Daisy
+  - [ ] JUCE
+  - [ ] VCV Rack

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,20 +7,3 @@
 ```
 - Please write a list of changes
 ```
-
-## Testing
-
-### Instructions
-
-...
-
-### Platforms
-
-- **Desktop**
-  - [ ] MacOS
-  - [ ] Linux
-  - [ ] Windows
-- **Environments**
-  - [ ] Daisy
-  - [ ] JUCE
-  - [ ] VCV Rack

--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -17,15 +17,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Prepare"
-        working-directory: ${{runner.workspace}}/cortex
-        run: cmake -E make_directory ${{runner.workspace}}/cortex/target
+        working-directory: ${{runner.workspace}}/neuron
+        run: cmake -E make_directory ${{runner.workspace}}/neuron/target
 
       - name: "Configure"
-        working-directory: ${{runner.workspace}}/cortex/target
-        run: cmake ${{runner.workspace}}/cortex
+        working-directory: ${{runner.workspace}}/neuron/target
+        run: cmake ${{runner.workspace}}/neuron
 
       - name: "Build"
-        working-directory: ${{runner.workspace}}/cortex/target
+        working-directory: ${{runner.workspace}}/neuron/target
         run: cmake --build .
 
   Make:

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -15,17 +15,17 @@ jobs:
                   submodules: recursive
 
             - name: "Prepare"
-              working-directory: ${{runner.workspace}}/cortex
+              working-directory: ${{runner.workspace}}/neuron
               run: mkdir -p target/test
 
             - name: "Generate Makefile"
-              working-directory: ${{runner.workspace}}/cortex/target/test
+              working-directory: ${{runner.workspace}}/neuron/target/test
               run: cmake -DBUILD_TESTS=ON ../../
 
             - name: "Build"
-              working-directory: ${{runner.workspace}}/cortex/target/test
+              working-directory: ${{runner.workspace}}/neuron/target/test
               run: make
 
             - name: "Test"
-              working-directory: ${{runner.workspace}}/cortex/target/test
+              working-directory: ${{runner.workspace}}/neuron/target/test
               run: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 option(BUILD_TESTS "Build unit tests" OFF)
 
-project(cortex VERSION 0.1.0 LANGUAGES CXX)
+project(neuron VERSION 0.1.0 LANGUAGES CXX)
 
 list(APPEND SOURCE
         src/generators/oscillator.cpp
@@ -23,36 +23,36 @@ list(APPEND INCLUDE_DIR
         "src/utilities"
 )
 
-add_library(cortex STATIC ${SOURCE})
+add_library(neuron STATIC ${SOURCE})
 
-set_target_properties(cortex PROPERTIES PUBLIC
+set_target_properties(neuron PROPERTIES PUBLIC
         CXX_STANDARD 14
         CXX_STANDARD_REQUIRED
 )
 
 if(BUILD_TESTS)
-    function(add_cortex_test name src)
+    function(add_neuron_test name src)
         add_executable("${name}_test_exe" ${src})
         target_include_directories("${name}_test_exe" PRIVATE ${INCLUDE_DIR})
-        target_link_libraries("${name}_test_exe" cortex)
+        target_link_libraries("${name}_test_exe" neuron)
         target_link_libraries("${name}_test_exe" gtest gtest_main)
         add_test(NAME "${name}_test" COMMAND "${name}_test_exe")
     endfunction()
 
     add_subdirectory(vendor/googletest)
 
-    add_cortex_test(waveform tests/audio/waveform_test.cpp)
-    add_cortex_test(oscillator tests/generators/oscillator_test.cpp)
-    add_cortex_test(adsr tests/modulators/adsr_test.cpp)
-    add_cortex_test(saturator tests/processors/effects/saturator_test.cpp)
-    add_cortex_test(wavefolder tests/processors/effects/wavefolder_test.cpp)
-    add_cortex_test(filter tests/processors/filters/filter_test.cpp)
-    add_cortex_test(arithmetic tests/utilities/arithmetic_test.cpp)
-    add_cortex_test(midi tests/utilities/midi_test.cpp)
+    add_neuron_test(waveform tests/audio/waveform_test.cpp)
+    add_neuron_test(oscillator tests/generators/oscillator_test.cpp)
+    add_neuron_test(adsr tests/modulators/adsr_test.cpp)
+    add_neuron_test(saturator tests/processors/effects/saturator_test.cpp)
+    add_neuron_test(wavefolder tests/processors/effects/wavefolder_test.cpp)
+    add_neuron_test(filter tests/processors/filters/filter_test.cpp)
+    add_neuron_test(arithmetic tests/utilities/arithmetic_test.cpp)
+    add_neuron_test(midi tests/utilities/midi_test.cpp)
 
     enable_testing()
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
-target_include_directories(cortex PUBLIC ${CMAKE_CURRENT_LIST_DIR}/src PRIVATE ${INCLUDE_DIR})
+target_include_directories(neuron PUBLIC ${CMAKE_CURRENT_LIST_DIR}/src PRIVATE ${INCLUDE_DIR})

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET = libcortex
+TARGET = libneuron
 
 MODULE_DIR = src
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# `cortex`
+# `neuron`
 
-[![Test](https://github.com/blackboxaudio/cortex/actions/workflows/ci.test.yml/badge.svg)](https://github.com/blackboxaudio/cortex/actions/workflows/ci.test.yml)
-[![Build](https://github.com/blackboxaudio/cortex/actions/workflows/ci.build.yml/badge.svg)](https://github.com/blackboxaudio/cortex/actions/workflows/ci.build.yml)
-[![cortex: v0.1.0](https://img.shields.io/badge/Version-v0.1.0-blue.svg)](https://github.com/blackboxaudio/cortex)
-[![License](https://img.shields.io/badge/License-MIT-yellow)](https://github.com/blackboxaudio/cortex/blob/develop/LICENSE)
+[![Test](https://github.com/blackboxaudio/neuron/actions/workflows/ci.test.yml/badge.svg)](https://github.com/blackboxaudio/neuron/actions/workflows/ci.test.yml)
+[![Build](https://github.com/blackboxaudio/neuron/actions/workflows/ci.build.yml/badge.svg)](https://github.com/blackboxaudio/neuron/actions/workflows/ci.build.yml)
+[![neuron: v0.1.0](https://img.shields.io/badge/Version-v0.1.0-blue.svg)](https://github.com/blackboxaudio/neuron)
+[![License](https://img.shields.io/badge/License-MIT-yellow)](https://github.com/blackboxaudio/neuron/blob/develop/LICENSE)
 
 > Collection of C++ audio DSP components 🧠
 
 ## Overview
 
-`cortex` is an open-source DSP (Digital Signal Processing) library that provides a wide-ranging suite of components for building audio software.
+`neuron` is an open-source DSP (Digital Signal Processing) library that provides a wide-ranging suite of components for building audio software.
 
 It can be used for a variety of applications, including:
 
@@ -19,7 +19,7 @@ It can be used for a variety of applications, including:
 
 ## Features
 
-`cortex` currently lacks wide support for features because it is in early stages, however the following are in its immediate roadmap:
+`neuron` currently lacks wide support for features because it is in early stages, however the following are in its immediate roadmap:
 
 - Dynamics
   - Compressor
@@ -57,8 +57,8 @@ It can be used for a variety of applications, including:
 
 Clone this repository:
 ```bash 
-git clone https://github.com/blackboxaudio/cortex
-cd cortex/
+git clone https://github.com/blackboxaudio/neuron
+cd neuron/
 ```
 
 Build the library:
@@ -69,7 +69,7 @@ make
 ## Using the Library
 
 ```c++
-#include "cortex.h"
+#include "neuron.h"
 
 // Create a DSP context (sample rate,
 // number of channels, buffer size).

--- a/src/audio/context.h
+++ b/src/audio/context.h
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-namespace cortex {
+namespace neuron {
 
 /**
  * Contains information about the context in which DSP operations

--- a/src/audio/sample.h
+++ b/src/audio/sample.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace cortex {
+namespace neuron {
 
 /**
  * The basic data type for DSP operations of

--- a/src/audio/waveform.h
+++ b/src/audio/waveform.h
@@ -3,7 +3,7 @@
 #include "audio/sample.h"
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 
 /**
  * The basic waveform variants, i.e. sine, triangle,

--- a/src/generators/oscillator.cpp
+++ b/src/generators/oscillator.cpp
@@ -1,6 +1,6 @@
 #include "generators/oscillator.h"
 
-using namespace cortex;
+using namespace neuron;
 
 Oscillator::Oscillator(Context& context, float frequency, Waveform waveform)
     : m_context(context)

--- a/src/generators/oscillator.h
+++ b/src/generators/oscillator.h
@@ -7,7 +7,7 @@
 #include "audio/waveform.h"
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 
 const size_t WAVETABLE_SIZE = 256;
 

--- a/src/modulators/adsr.cpp
+++ b/src/modulators/adsr.cpp
@@ -1,6 +1,6 @@
 #include "modulators/adsr.h"
 
-using namespace cortex;
+using namespace neuron;
 
 AdsrEnvelopeModulator::AdsrEnvelopeModulator(Context& context, AdsrEnvelope envelope)
     : m_context(context)

--- a/src/modulators/adsr.h
+++ b/src/modulators/adsr.h
@@ -2,7 +2,7 @@
 
 #include "audio/context.h"
 
-namespace cortex {
+namespace neuron {
 
 /**
  * The configuration of an ADSR envelope curve including durations

--- a/src/neuron.h
+++ b/src/neuron.h
@@ -1,12 +1,12 @@
 /**
- * Cortex is a lightweight audio DSP library intended for use
+ * Neuron is a lightweight audio DSP library intended for use
  * in any relevant application e.g. Electrosmith Daisy patches,
  * JUCE plugins, VCV Rack modules.
  *
  * Author: Matthew Maxwell, 2024
  */
-#ifndef CORTEX_LIB_H
-#define CORTEX_LIB_H
+#ifndef NEURON_LIB_H
+#define NEURON_LIB_H
 
 // AUDIO
 #include "audio/context.h"

--- a/src/processors/effects/saturator.cpp
+++ b/src/processors/effects/saturator.cpp
@@ -1,6 +1,6 @@
 #include "processors/effects/saturator.h"
 
-using namespace cortex;
+using namespace neuron;
 
 Sample Saturator::Process(const Sample input)
 {

--- a/src/processors/effects/saturator.h
+++ b/src/processors/effects/saturator.h
@@ -3,7 +3,7 @@
 #include "audio/sample.h"
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 
 /**
  * The Saturator class applies a tape saturation

--- a/src/processors/effects/wavefolder.cpp
+++ b/src/processors/effects/wavefolder.cpp
@@ -1,6 +1,6 @@
 #include "processors/effects/wavefolder.h"
 
-using namespace cortex;
+using namespace neuron;
 
 Sample Wavefolder::Process(const Sample input)
 {

--- a/src/processors/effects/wavefolder.h
+++ b/src/processors/effects/wavefolder.h
@@ -3,7 +3,7 @@
 #include "audio/sample.h"
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 
 /**
  * The Wavefolder class applies a wavefolding

--- a/src/processors/filters/filter.cpp
+++ b/src/processors/filters/filter.cpp
@@ -1,8 +1,8 @@
 #include "processors/filters/filter.h"
 
-using namespace cortex;
+using namespace neuron;
 
-Filter::Filter(cortex::Context& context, float cutoffFrequency)
+Filter::Filter(neuron::Context& context, float cutoffFrequency)
     : m_context(context)
     , m_cutoffFrequency(cutoffFrequency)
     , m_previousOutput(0.0f)
@@ -10,7 +10,7 @@ Filter::Filter(cortex::Context& context, float cutoffFrequency)
     SetCutoffFrequency(cutoffFrequency);
 }
 
-Sample Filter::Process(const cortex::Sample input)
+Sample Filter::Process(const neuron::Sample input)
 {
     float output = m_alpha * (float)input + (1.0f - m_alpha) * (float)m_previousOutput;
     m_previousOutput = (Sample)output;

--- a/src/processors/filters/filter.h
+++ b/src/processors/filters/filter.h
@@ -4,7 +4,7 @@
 #include "audio/sample.h"
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 const float FILTER_CUTOFF_FREQ_MIN = 20.0f;
 const float FILTER_CUTOFF_FREQ_MAX = 20000.0f;
 

--- a/src/utilities/arithmetic.h
+++ b/src/utilities/arithmetic.h
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace cortex {
+namespace neuron {
 
 /**
  * A value for the absence of quantity; nothing.

--- a/src/utilities/logger.cpp
+++ b/src/utilities/logger.cpp
@@ -3,7 +3,7 @@
 #include <ctime>
 #include <iostream>
 
-using namespace cortex;
+using namespace neuron;
 
 void Logger::Log(std::string str)
 {
@@ -13,5 +13,5 @@ void Logger::Log(std::string str)
     std::strftime(buffer, sizeof(buffer), "Y-%m-%d %H:%M:%S", localTime);
 
     std::cout << "[" << buffer << "] "
-              << "CORTEX: " << str << std::endl;
+              << "NEURON: " << str << std::endl;
 }

--- a/src/utilities/logger.h
+++ b/src/utilities/logger.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace cortex {
+namespace neuron {
 
 class Logger {
 public:
@@ -11,7 +11,7 @@ public:
 
 }
 
-#define CX_TRACE(...) ::cortex::Logger::Log(__VA_ARGS__)
-#define CX_INFO(...) ::cortex::Logger::Log(__VA_ARGS__)
-#define CX_WARN(...) ::cortex::Logger::Log(__VA_ARGS__)
-#define CX_ERROR(...) ::cortex::Logger::Log(__VA_ARGS__)
+#define NEO_TRACE(...) ::neuron::Logger::Log(__VA_ARGS__)
+#define NEO_INFO(...) ::neuron::Logger::Log(__VA_ARGS__)
+#define NEO_WARN(...) ::neuron::Logger::Log(__VA_ARGS__)
+#define NEO_ERROR(...) ::neuron::Logger::Log(__VA_ARGS__)

--- a/src/utilities/midi.h
+++ b/src/utilities/midi.h
@@ -4,7 +4,7 @@
 
 #include "utilities/arithmetic.h"
 
-namespace cortex {
+namespace neuron {
 
 /**
  * Converts a MIDI note number to a (floating-point) frequency. Any value outside

--- a/src/utilities/timer.h
+++ b/src/utilities/timer.h
@@ -2,7 +2,7 @@
 
 #include "utilities/logger.h"
 
-namespace cortex {
+namespace neuron {
 
 class Timer {
 public:
@@ -24,7 +24,7 @@ public:
         auto end = std::chrono::time_point_cast<std::chrono::microseconds>(endTimepoint).time_since_epoch().count();
 
         auto durationMs = (end - start) * 0.001f;
-        CX_INFO(std::to_string(durationMs) + "ms");
+        NEO_INFO(std::to_string(durationMs) + "ms");
     }
 
 private:

--- a/tests/audio/waveform_test.cpp
+++ b/tests/audio/waveform_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(waveform_suite, sine_conversion_test)
 {

--- a/tests/generators/oscillator_test.cpp
+++ b/tests/generators/oscillator_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(oscillator_suite, generate_test)
 {

--- a/tests/modulators/adsr_test.cpp
+++ b/tests/modulators/adsr_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(adsr_suite, trigger_test)
 {

--- a/tests/processors/effects/saturator_test.cpp
+++ b/tests/processors/effects/saturator_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(saturator_suite, process_test)
 {

--- a/tests/processors/effects/wavefolder_test.cpp
+++ b/tests/processors/effects/wavefolder_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(wavefolder_suite, process_test)
 {

--- a/tests/processors/filters/filter_test.cpp
+++ b/tests/processors/filters/filter_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(filter_suite, basic_test)
 {

--- a/tests/utilities/arithmetic_test.cpp
+++ b/tests/utilities/arithmetic_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(arithmetic_suite, clamp_test)
 {

--- a/tests/utilities/midi_test.cpp
+++ b/tests/utilities/midi_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "cortex.h"
+#include "neuron.h"
 
-using namespace cortex;
+using namespace neuron;
 
 TEST(midi_suite, midi_to_frequency_test)
 {


### PR DESCRIPTION
## Summary

`cortex` is to become another library with a different purpose while `neuron` is more befitting for DSP building blocks that are used to compose larger, more complex signal chains.

## Changelog

```
- Replace all usages of "cortex" with "neuron"
```
